### PR TITLE
Pass test for `RequestDeniedException` being thrown from `DoAuthenticatedRequest`

### DIFF
--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -94,8 +94,15 @@ namespace StopWatch
         public string GetIssueSummary(string key, bool addProjectName)
         {
             var request = jiraApiRequestFactory.CreateGetIssueSummaryRequest(key);
-            var issue = jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields;
-            return addProjectName ? issue.Project.Name + ": " + issue.Summary : issue.Summary;
+            try
+            {
+                var issue = jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields;
+                return addProjectName ? issue.Project.Name + ": " + issue.Summary : issue.Summary;
+            }
+            catch (RequestDeniedException)
+            {
+                return string.Empty;
+            }
         }
 
         public TimetrackingFields GetIssueTimetracking(string key)


### PR DESCRIPTION
The test `GetIssueSummary_OnFailure_It_Returns_Empty_String` was failing due to missing handling for the `RequestDeniedException` thrown.