### PR TITLE
Remove unused solution items

### DIFF
--- a/StopWatch.sln
+++ b/StopWatch.sln
@@ -1,16 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StopWatch", "source\StopWatch\StopWatch.csproj", "{B7C11B2A-F064-4BA4-BD87-954197D7FF35}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D8C61A83-5EA6-4C4B-993E-AA68E458F1E9}"
-	ProjectSection(SolutionItems) = preProject
-		LICENSE.rtf = LICENSE.rtf
-		LICENSE.txt = LICENSE.txt
-		README.md = README.md
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StopWatchTest", "source\StopWatchTest\StopWatchTest.csproj", "{7F60E6E6-B488-4A6E-868B-796E3A42F552}"
 EndProject
@@ -31,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5B0ED504-86F9-437D-973D-6E948BF73E27}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This removes the README and old license files from the solution, which is not necessary and the license files have been moved anyway.