### PR TITLE
Change FormBorderStyle of About and Settings to FixedToolWindow

### DIFF
--- a/source/StopWatch/UI/AboutForm.Designer.cs
+++ b/source/StopWatch/UI/AboutForm.Designer.cs
@@ -135,6 +135,7 @@ namespace StopWatch
             this.Controls.Add(this.pictureBox1);
             this.Controls.Add(this.lblLicense);
             this.Controls.Add(this.lblNameVersion);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Icon = global::StopWatch.Properties.Resources.stopwatchicon;
             this.Name = "AboutForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/source/StopWatch/UI/SettingsForm.Designer.cs
+++ b/source/StopWatch/UI/SettingsForm.Designer.cs
@@ -405,6 +405,7 @@ namespace StopWatch
             this.Controls.Add(this.lblDisplayOptions);
             this.Controls.Add(this.tbJiraBaseUrl);
             this.Controls.Add(this.lblJiraBaseUrl);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Icon = global::StopWatch.Properties.Resources.stopwatchicon;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "SettingsForm";


### PR DESCRIPTION
<!-- LIST CHANGES HERE -->

The Settings and About Windows were resizable, which they are clearly not supposed to be. Now they'll be changed to FixedToolWindows. Due to them being a Dialog and therefore staying in foreground, a MinimizeBox is unnecessary -> FixedToolWindow.