### PR TITLE
Change FormBorderStyle of EditTimeForm to FixedToolWindow

### DIFF
--- a/source/StopWatch/UI/EditTimeForm.Designer.cs
+++ b/source/StopWatch/UI/EditTimeForm.Designer.cs
@@ -124,6 +124,7 @@ namespace StopWatch
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.lblHeader);
             this.Controls.Add(this.tbTime);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "EditTimeForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit Timer";


### PR DESCRIPTION
The EditTimeForm was resizable, which it clearly is not supposed to be. Now it's changed to FixedToolWindows. Due to it being a Dialog and therefore staying in foreground, a MinimizeBox is unnecessary -> FixedToolWindow.