### PR TITLE
JiraTimeToTimeSpan: Correctly calculate days with workingHoursPerDay

### DIFF
--- a/source/StopWatch/Helpers/JiraTimeHelpers.cs
+++ b/source/StopWatch/Helpers/JiraTimeHelpers.cs
@@ -103,7 +103,7 @@ namespace StopWatch
                     minutes += (int)(t * 60);
 
                 if (s.Contains("D"))
-                    minutes += (int)(t * 60 * 24);
+                    minutes += Configuration != null ? (int)(t * 60 * 24 / (24 / (decimal)Configuration.workingHoursPerDay)) : (int)(t * 60 * 24);
                 
                 if (minutes < 0)
                     minutes = 0;


### PR DESCRIPTION
<!-- LIST CHANGES HERE -->
In the JiraTimeToTimeSpan Function was the workingHoursPerDay not being considered when calculating the days.

If you had for example 8h (work) per day and edited the time to 8h this happened:
* Enter 8h
* Close Dialog
* 8h becomes 1d
* Open Dialog
* Close Dialog
* 1d is 3*8h which is 3d
* 3d is displayed

In the commit I just divide the days by 24 / workingHoursPerDay, which then becomes the "real" amount of days again.